### PR TITLE
fix(ontology): correct OWL/BFO axiom errors across core, intermediate, and cases ontologies

### DIFF
--- a/ontologies/proethica-cases.ttl
+++ b/ontologies/proethica-cases.ttl
@@ -356,7 +356,7 @@ proeth-cases:DecisionOption rdfs:subClassOf [
 proeth-cases:Case rdfs:subClassOf [
     a owl:Restriction ;
     owl:onProperty proeth-cases:involvesStakeholder ;
-    owl:someValuesFrom proeth-core:Role
+    owl:someValuesFrom proeth-cases:Stakeholder
 ] .
 
 ###############################################################

--- a/ontologies/proethica-cases.ttl
+++ b/ontologies/proethica-cases.ttl
@@ -219,12 +219,17 @@ proeth-cases:involvesRole a owl:ObjectProperty ;
     skos:definition "Relates an ethical case to a professional role that is central to or involved in the case scenario."@en .
 
 proeth-cases:triggeredByEvent a owl:ObjectProperty ;
-    rdfs:subPropertyOf ro:0000013 ;  # RO:causally downstream of
+    # RO_0000013 does not exist. 'causally downstream of' is not a standard RO IRI.
+    # A Case (information content entity) cannot participate in causal relations per BFO.
+    # The inverse of causally-upstream-of is RO_0002427 (causally downstream of or within).
+    # However, Cases are not processes/occurrents so RO causal relations do not directly apply.
+    # We therefore leave this without an RO subPropertyOf and model it as a domain-specific link.
     rdfs:domain proeth-cases:Case ;
     rdfs:range proeth-core:Event ;
     rdfs:label "triggered by event"@en ;
-    rdfs:comment "Relates a case to events that initiated or precipitated the ethical scenario."@en ;
-    skos:definition "Relates an ethical case to an event that initiated, precipitated, or contributed to the development of the case scenario."@en .
+    rdfs:comment "Relates a case (as an information content entity representing the scenario) to events that initiated or precipitated the ethical situation."@en ;
+    skos:definition "Relates an ethical case to an event that initiated, precipitated, or contributed to the development of the case scenario."@en ;
+    skos:changeNote "v2.0.1: Removed rdfs:subPropertyOf ro:0000013 — RO_0000013 does not exist in the OBO Relations Ontology. Cases are ICEs (GDC) not processes, so RO causal relations do not apply directly."@en .
 
 proeth-cases:requiresAction a owl:ObjectProperty ;
     rdfs:domain proeth-cases:DecisionOption ;
@@ -333,24 +338,25 @@ proeth-cases:resolutionUrgency a owl:DatatypeProperty ;
 ###############################################################
 
 # Every case must have at least one decision option
+# Using owl:someValuesFrom (OBO/BFO standard pattern) rather than owl:minCardinality.
 proeth-cases:Case rdfs:subClassOf [
     a owl:Restriction ;
     owl:onProperty proeth-cases:hasDecisionOption ;
-    owl:minCardinality "1"^^xsd:nonNegativeInteger
+    owl:someValuesFrom proeth-cases:DecisionOption
 ] .
 
 # Every decision option should have at least one supporting or opposing argument
 proeth-cases:DecisionOption rdfs:subClassOf [
     a owl:Restriction ;
     owl:onProperty proeth-cases:hasArgument ;
-    owl:minCardinality "1"^^xsd:nonNegativeInteger
+    owl:someValuesFrom proeth-cases:Argument
 ] .
 
 # Cases should involve at least one stakeholder
 proeth-cases:Case rdfs:subClassOf [
     a owl:Restriction ;
     owl:onProperty proeth-cases:involvesStakeholder ;
-    owl:minCardinality "1"^^xsd:nonNegativeInteger
+    owl:someValuesFrom proeth-core:Role
 ] .
 
 ###############################################################

--- a/ontologies/proethica-core.ttl
+++ b/ontologies/proethica-core.ttl
@@ -17,7 +17,7 @@
     dc:creator "ProEthica AI"@en ;
     dc:date "2026-02-19"^^xsd:date ;
     rdfs:comment "Core ontology defining the formal specification D=(R,P,O,S,Rs,A,E,Ca,Cs) with CodeProvision extension for ethics code integration."@en ;
-    owl:versionInfo "2.4.0"^^xsd:string ;
+    owl:versionInfo "2.4.1"^^xsd:string ;
     owl:imports <http://purl.obolibrary.org/obo/bfo.owl> ;
     owl:imports <http://purl.obolibrary.org/obo/iao.owl> ;
     owl:imports <http://purl.obolibrary.org/obo/ro.owl> ;
@@ -113,7 +113,7 @@ proeth-core:CodeProvision a owl:Class ;
 
 # Guideline: Container for provisions (the full code document)
 proeth-core:Guideline a owl:Class ;
-    rdfs:subClassOf iao:0000310 ;  # IAO:document part (or could be iao:0000300 document)
+    rdfs:subClassOf iao:0000310 ;  # IAO:document (IAO_0000310 = "document" — codes of ethics are documents)
     rdfs:label "Guideline"@en ;
     rdfs:comment "A professional code of ethics or guideline document containing multiple provisions. Examples include NSPE Code of Ethics, NEA Code of Ethics, ACM Code of Ethics."@en ;
     skos:definition "A formal document establishing ethical standards for a profession, containing individual CodeProvisions."@en .
@@ -166,6 +166,15 @@ proeth-core:performsAction a owl:ObjectProperty ;
     rdfs:comment "Relates an agent to actions they perform."@en ;
     skos:definition "Relates an agent to actions they perform."@en .
 
+proeth-core:isPerformedBy a owl:ObjectProperty ;
+    owl:inverseOf proeth-core:performsAction ;
+    rdfs:domain proeth-core:Action ;
+    rdfs:range proeth-core:Agent ;
+    rdfs:label "is performed by"@en ;
+    rdfs:comment "Relates an action to the agent that performs it. Inverse of performsAction."@en ;
+    skos:definition "Relates an action to the agent responsible for performing it."@en ;
+    skos:changeNote "v2.4.1: Added as named inverse of performsAction to support OWL DL-compliant cardinality restriction on Action."@en .
+
 proeth-core:fulfillsObligation a owl:ObjectProperty ;
     rdfs:domain proeth-core:Action ;
     rdfs:range proeth-core:Obligation ;
@@ -196,12 +205,13 @@ proeth-core:usesResource a owl:ObjectProperty ;
     skos:definition "Relates an action to resources it utilizes."@en .
 
 proeth-core:triggersEvent a owl:ObjectProperty ;
-    rdfs:subPropertyOf ro:0000012 ;  # RO:causally upstream of
+    rdfs:subPropertyOf ro:0002411 ;  # RO:causally upstream of (RO_0002411)
     rdfs:domain proeth-core:Action ;
     rdfs:range proeth-core:Event ;
     rdfs:label "triggers event"@en ;
     rdfs:comment "Relates an action to events it causes or initiates."@en ;
-    skos:definition "Relates an action to events it causes or initiates."@en .
+    skos:definition "Relates an action to events it causes or initiates."@en ;
+    skos:changeNote "v2.4.1: Corrected RO IRI from non-existent ro:0000012 to ro:0002411 (causally upstream of). RO_0002411 is the correct IRI for 'causally upstream of' in the OBO Relations Ontology."@en .
 
 proeth-core:constrainedBy a owl:ObjectProperty ;
     rdfs:domain proeth-core:Action ;
@@ -337,17 +347,20 @@ proeth-core:citesAuthority a owl:ObjectProperty ;
 ###############################################################
 
 # Ensure every role has at least one obligation
+# Using owl:someValuesFrom (OBO/BFO standard existential pattern) rather than
+# owl:minCardinality which is unqualified and does not specify the filler type.
 proeth-core:Role rdfs:subClassOf [
     a owl:Restriction ;
     owl:onProperty proeth-core:hasObligation ;
-    owl:minCardinality "1"^^xsd:nonNegativeInteger
+    owl:someValuesFrom proeth-core:Obligation
 ] .
 
-# Ensure every action has an agent participant  
+# Ensure every action is performed by at least one agent
+# Uses named inverse property isPerformedBy (OWL DL compliant — no anonymous inverseOf in restriction).
 proeth-core:Action rdfs:subClassOf [
     a owl:Restriction ;
-    owl:onProperty [ owl:inverseOf proeth-core:performsAction ] ;
-    owl:minCardinality "1"^^xsd:nonNegativeInteger
+    owl:onProperty proeth-core:isPerformedBy ;
+    owl:someValuesFrom proeth-core:Agent
 ] .
 
 ###############################################################

--- a/ontologies/proethica-intermediate.ttl
+++ b/ontologies/proethica-intermediate.ttl
@@ -463,10 +463,13 @@ proeth:owlTimeProperty a owl:DatatypeProperty ;
     rdfs:seeAlso :Principle .
 
 :ProfessionalObligation rdf:type owl:Class ;
-    rdfs:subClassOf bfo:BFO_0000017 ; # realizable entity
+    # NOTE: bfo:BFO_0000017 (realizable entity / SDC) removed — it conflicts with proeth-core:Obligation
+    # which is IAO:directive information entity (GDC). BFO GDC and SDC are mutually exclusive,
+    # so having both superclasses would make this class unsatisfiable in a reasoning context.
     rdfs:subClassOf proeth-core:Obligation ;
     rdfs:label "Professional Obligation"@en ;
-    rdfs:comment "A duty or responsibility arising from professional role or standards"@en .
+    rdfs:comment "A duty or responsibility arising from professional role or standards. As a directive information entity (IAO:0000033 via proeth-core:Obligation), it is a generically dependent continuant — not a realizable entity."@en ;
+    skos:changeNote "v2.x: Removed rdfs:subClassOf bfo:BFO_0000017 (realizable entity/SDC). Obligations are directive information entities (GDC), and SDC+GDC dual-inheritance is inconsistent in BFO."@en .
 
 # Obligation Categories from Chapter 2 Literature
 # Based on Dennis et al. (2016), Anderson & Anderson, NSPE Code
@@ -532,11 +535,12 @@ proeth:CollegialObligation a owl:Class ;
     rdfs:comment "Duties toward professional peers including respect, fairness, and credit for work"@en .
 
 # Obligation properties for temporal and contextual aspects
-proeth:hasEnforcementLevel a owl:ObjectProperty ;
+proeth:hasEnforcementLevel a owl:DatatypeProperty ;  # was owl:ObjectProperty — corrected: range is xsd:string
     rdfs:domain proeth-core:Obligation ;
     rdfs:range xsd:string ;
     rdfs:label "has enforcement level"@en ;
-    rdfs:comment "Specifies whether obligation is mandatory, strongly recommended, or recommended"@en .
+    rdfs:comment "Specifies whether obligation is mandatory, strongly recommended, or recommended"@en ;
+    skos:changeNote "v2.x: Changed from owl:ObjectProperty to owl:DatatypeProperty. Properties with rdfs:range xsd:string must be DatatypeProperties."@en .
 
 proeth:derivedFromPrinciple a owl:ObjectProperty ;
     rdfs:domain proeth-core:Obligation ;
@@ -1193,11 +1197,12 @@ proeth:PriorityConstraint a owl:Class ;
     dcterms:references <https://doi.org/10.1075/is.15.2.05sch> . # Scheutz & Malle 2014
 
 # Constraint properties for relationships
-proeth:hasConstraintType a owl:ObjectProperty ;
+proeth:hasConstraintType a owl:DatatypeProperty ;  # was owl:ObjectProperty — corrected: range is xsd:string
     rdfs:domain proeth-core:Constraint ;
     rdfs:range xsd:string ;
     rdfs:label "has constraint type"@en ;
-    rdfs:comment "Specifies the type of constraint (legal, regulatory, resource, etc.)"@en .
+    rdfs:comment "Specifies the type of constraint (legal, regulatory, resource, etc.)"@en ;
+    skos:changeNote "v2.x: Changed from owl:ObjectProperty to owl:DatatypeProperty. A property relating to a string literal must be a DatatypeProperty."@en .
 
 proeth:constrainsAction a owl:ObjectProperty ;
     rdfs:domain proeth-core:Constraint ;
@@ -1314,11 +1319,12 @@ proeth:PrecedentRetrieval a owl:Class ;
     dcterms:references <https://doi.org/10.1023/B:AIRE.0000009444.71972.2e> . # McLaren 2003
 
 # Capability properties for relationships
-proeth:hasCapabilityLevel a owl:ObjectProperty ;
+proeth:hasCapabilityLevel a owl:DatatypeProperty ;  # was owl:ObjectProperty — corrected: range is xsd:string
     rdfs:domain proeth-core:Capability ;
     rdfs:range xsd:string ;
     rdfs:label "has capability level"@en ;
-    rdfs:comment "Indicates the level or degree of a capability"@en .
+    rdfs:comment "Indicates the level or degree of a capability"@en ;
+    skos:changeNote "v2.x: Changed from owl:ObjectProperty to owl:DatatypeProperty. A property relating to a string literal must be a DatatypeProperty."@en .
 
 proeth:enablesAction a owl:ObjectProperty ;
     rdfs:domain proeth-core:Capability ;


### PR DESCRIPTION
## Summary

Formal audit of the ProEthica ontology axioms against the OWL 2 spec, BFO 2.0 (`bfo-2.0.owl`), IAO (`iao-2020.owl`), and RO (`ro-2015.owl`) identified 7 issues — 4 critical, 2 significant, 1 minor. All have been corrected.

## Files Changed

- `ontologies/proethica-core.ttl` (bumped to v2.4.1)
- `ontologies/proethica-intermediate.ttl`
- `ontologies/proethica-cases.ttl`

## Issues Fixed

### 🔴 Critical

**1. Wrong RO IRI — `ro:0000012` does not exist**
- `proethica-core.ttl` line 199: `triggersEvent rdfs:subPropertyOf ro:0000012`
- Verified against `ro-2015.owl`: `RO_0000012` returns zero triples
- **Fixed**: Changed to `ro:0002411` (`causally upstream of`, verified label in RO)

**2. Wrong RO IRI — `ro:0000013` does not exist**
- `proethica-cases.ttl` line 222: `triggeredByEvent rdfs:subPropertyOf ro:0000013`
- **Fixed**: Removed invalid `subPropertyOf`; Cases are ICEs (GDC), not occurrents, so RO causal relations do not apply directly

**3. `owl:ObjectProperty` with `rdfs:range xsd:string` — type mismatch**
- `proethica-intermediate.ttl`: `hasConstraintType`, `hasCapabilityLevel`, `hasEnforcementLevel` declared as `owl:ObjectProperty` but range is `xsd:string`
- **Fixed**: Changed all three to `owl:DatatypeProperty`

**4. Anonymous `owl:inverseOf` inside a property restriction**
- `proethica-core.ttl`: `Action rdfs:subClassOf [ owl:onProperty [ owl:inverseOf performsAction ] ... ]`
- Anonymous inverse property expressions in restrictions push the ontology toward OWL Full and no named inverse existed
- **Fixed**: Declared named property `proeth-core:isPerformedBy` with `owl:inverseOf proeth-core:performsAction`; restriction now uses named property

**5. `ProfessionalObligation` is both SDC (realizable entity) and GDC (Obligation) — would be unsatisfiable**
- `proethica-intermediate.ttl`: `ProfessionalObligation rdfs:subClassOf bfo:BFO_0000017` (realizable/SDC) **AND** `rdfs:subClassOf proeth-core:Obligation` (directive ICE/GDC)
- BFO GDC and SDC are mutually exclusive — a reasoner would flag this as unsatisfiable
- **Fixed**: Removed the `BFO_0000017` (SDC) superclass

### 🟡 Significant

**6. `owl:minCardinality` instead of `owl:someValuesFrom` in SubClassOf restrictions**
- Unqualified cardinality does not constrain the filler type; OBO/BFO standard pattern is `owl:someValuesFrom`
- **Fixed**: Replaced all `owl:minCardinality "1"` restrictions with `owl:someValuesFrom <filler>` in `proethica-core.ttl` and `proethica-cases.ttl`

### 🟢 Minor

**7. Incorrect comment — IAO:0000310 = 'document', not 'document part'**
- `proethica-core.ttl` Guideline class comment
- **Fixed**: Corrected comment (subClassOf is correct, only comment was wrong)

## Verification

- All three ontology files parse cleanly with rdflib (322, 1128, 556 triples respectively)
- `RO_0002411` verified as "causally upstream of" by querying `ro-2015.owl`
- `owl:minCardinality` confirmed absent from `proethica-core.ttl`
- `hasConstraintType`, `hasCapabilityLevel`, `hasEnforcementLevel` confirmed as `DatatypeProperty`
- `ProfessionalObligation` confirmed with single superclass (`proeth-core:Obligation`)
- Unit test suite: **129 passed, 3 skipped** (no regressions)